### PR TITLE
Transport tests

### DIFF
--- a/cmd/dial/main.go
+++ b/cmd/dial/main.go
@@ -13,7 +13,8 @@ func main() {
 	addr := &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 4444}
 
 	// Generate a certificate and private key to secure the connection
-	certificate, privateKey := cmd.GenerateCertificate()
+	certificate, privateKey, genErr := dtls.GenerateSelfSigned()
+	cmd.Check(genErr)
 
 	//
 	// Everything below is the pion-DTLS API! Thanks for using it ❤️.

--- a/cmd/listen/main.go
+++ b/cmd/listen/main.go
@@ -17,7 +17,8 @@ func main() {
 	addr := &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 4444}
 
 	// Generate a certificate and private key to secure the connection
-	certificate, privateKey := cmd.GenerateCertificate()
+	certificate, privateKey, genErr := dtls.GenerateSelfSigned()
+	cmd.Check(genErr)
 
 	//
 	// Everything below is the pion-DTLS API! Thanks for using it ❤️.

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -2,18 +2,10 @@ package cmd
 
 import (
 	"bufio"
-	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/rand"
-	"crypto/x509"
-	"crypto/x509/pkix"
-	"encoding/hex"
 	"fmt"
 	"io"
-	"math/big"
 	"os"
 	"strings"
-	"time"
 )
 
 const bufSize = 8192
@@ -41,45 +33,6 @@ func Chat(conn io.ReadWriter) {
 		_, err = conn.Write([]byte(text))
 		Check(err)
 	}
-}
-
-// GenerateCertificate is a helper to generate a certificate and private key
-func GenerateCertificate() (*x509.Certificate, *ecdsa.PrivateKey) {
-	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	Check(err)
-
-	origin := make([]byte, 16)
-	Check(err)
-
-	// Max random value, a 130-bits integer, i.e 2^130 - 1
-	maxBigInt := new(big.Int)
-	/* #nosec */
-	maxBigInt.Exp(big.NewInt(2), big.NewInt(130), nil).Sub(maxBigInt, big.NewInt(1))
-	serialNumber, err := rand.Int(rand.Reader, maxBigInt)
-	Check(err)
-
-	template := x509.Certificate{
-		ExtKeyUsage: []x509.ExtKeyUsage{
-			x509.ExtKeyUsageClientAuth,
-			x509.ExtKeyUsageServerAuth,
-		},
-		BasicConstraintsValid: true,
-		NotBefore:             time.Now(),
-		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
-		NotAfter:              time.Now().AddDate(0, 1, 0),
-		SerialNumber:          serialNumber,
-		Version:               2,
-		Subject:               pkix.Name{CommonName: hex.EncodeToString(origin)},
-		IsCA:                  true,
-	}
-
-	raw, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
-	Check(err)
-
-	cert, err := x509.ParseCertificate(raw)
-	Check(err)
-
-	return cert, priv
 }
 
 // Check is a helper to throw errors in the examples

--- a/pkg/dtls/conn_test.go
+++ b/pkg/dtls/conn_test.go
@@ -1,0 +1,118 @@
+package dtls
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/pions/transport/test"
+)
+
+// Seems to strict for out implementation at this point
+// func TestNetTest(t *testing.T) {
+// 	lim := test.TimeOut(time.Minute*1 + time.Second*10)
+// 	defer lim.Stop()
+//
+// 	nettest.TestConn(t, func() (c1, c2 net.Conn, stop func(), err error) {
+// 		c1, c2, err = pipeMemory()
+// 		if err != nil {
+// 			return nil, nil, nil, err
+// 		}
+// 		stop = func() {
+// 			c1.Close()
+// 			c2.Close()
+// 		}
+// 		return
+// 	})
+// }
+
+func TestStressDuplex(t *testing.T) {
+	lim := test.TimeOut(time.Second * 5)
+	defer lim.Stop()
+
+	ca, cb, err := pipeMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer func() {
+		err = ca.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = cb.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	opt := test.Options{
+		MsgSize:  2048,
+		MsgCount: 100,
+	}
+
+	err = test.StressDuplex(ca, cb, opt)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func pipeMemory() (*Conn, *Conn, error) {
+	// In memory pipe
+	ca, cb := net.Pipe()
+
+	type result struct {
+		c   *Conn
+		err error
+	}
+
+	c := make(chan result)
+
+	// Setup client
+	go func() {
+		client, err := testClient(ca)
+		c <- result{client, err}
+	}()
+
+	// Setup server
+	server, err := testServer(cb)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Receive client
+	res := <-c
+	if res.err != nil {
+		return nil, nil, res.err
+	}
+
+	return res.c, server, nil
+}
+
+func testClient(c net.Conn) (*Conn, error) {
+	clientCert, clientKey, err := GenerateSelfSigned()
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := Client(c, &Config{clientCert, clientKey})
+	if err != nil {
+		return nil, err
+	}
+
+	return client, nil
+}
+
+func testServer(c net.Conn) (*Conn, error) {
+	serverCert, serverKey, err := GenerateSelfSigned()
+	if err != nil {
+		return nil, err
+	}
+
+	server, err := Server(c, &Config{serverCert, serverKey})
+	if err != nil {
+		return nil, err
+	}
+
+	return server, nil
+}

--- a/pkg/dtls/listener.go
+++ b/pkg/dtls/listener.go
@@ -40,6 +40,7 @@ func (l *Listener) Accept() (net.Conn, error) {
 
 // Close closes the listener.
 // Any blocked Accept operations will be unblocked and return errors.
+// Already Accepted connections are not closed.
 func (l *Listener) Close() error {
 	return l.parent.Close()
 }


### PR DESCRIPTION
I created [pions/transport](https://github.com/pions/transport) and added those tests. ~I also added a test based on [x/net/nettest](https://golang.org/x/net/nettest). This one still fails. The idea is to merge this and #23 to come to a solid test suite, that's also usable for the other network layers. Afterwards we can extend it with things like tests with unreliable connections etc.~