### PR TITLE
Adapt ExportKeyingMaterial to crypto/tls

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -214,7 +214,7 @@ func (c *Conn) RemoteCertificate() *x509.Certificate {
 // ExportKeyingMaterial from https://tools.ietf.org/html/rfc5705
 // This allows protocols to use DTLS for key establishment, but
 // then use some of the keying material for their own purposes
-func (c *Conn) ExportKeyingMaterial(label []byte, context []byte, length int) ([]byte, error) {
+func (c *Conn) ExportKeyingMaterial(label string, context []byte, length int) ([]byte, error) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
@@ -222,7 +222,7 @@ func (c *Conn) ExportKeyingMaterial(label []byte, context []byte, length int) ([
 		return nil, errHandshakeInProgress
 	} else if len(context) != 0 {
 		return nil, errContextUnsupported
-	} else if _, ok := invalidKeyingLabels[string(label)]; ok {
+	} else if _, ok := invalidKeyingLabels[label]; ok {
 		return nil, errReservedExportKeyingMaterial
 	}
 
@@ -235,7 +235,7 @@ func (c *Conn) ExportKeyingMaterial(label []byte, context []byte, length int) ([
 		return nil, err
 	}
 
-	seed := append([]byte{}, label...)
+	seed := []byte(label)
 	if c.isClient {
 		seed = append(append(seed, localRandom...), remoteRandom...)
 	} else {

--- a/conn_test.go
+++ b/conn_test.go
@@ -130,7 +130,7 @@ func testServer(c net.Conn) (*Conn, error) {
 
 func TestExportKeyingMaterial(t *testing.T) {
 	var rand [28]byte
-	exportLabel := []byte("EXTRACTOR-dtls_srtp")
+	exportLabel := "EXTRACTOR-dtls_srtp"
 
 	expectedServerKey := []byte{0x61, 0x09, 0x9d, 0x7d, 0xcb, 0x08, 0x52, 0x2c, 0xe7, 0x7b}
 	expectedClientKey := []byte{0x87, 0xf0, 0x40, 0x02, 0xf6, 0x1c, 0xf1, 0xfe, 0x8c, 0x77}
@@ -153,7 +153,7 @@ func TestExportKeyingMaterial(t *testing.T) {
 	}
 
 	for k := range invalidKeyingLabels {
-		_, err = c.ExportKeyingMaterial([]byte(k), nil, 0)
+		_, err = c.ExportKeyingMaterial(k, nil, 0)
 		if err != errReservedExportKeyingMaterial {
 			t.Errorf("ExportKeyingMaterial reserved label: expected '%s' actual '%s'", errReservedExportKeyingMaterial, err)
 		}


### PR DESCRIPTION
Changed the signature of Conn.ExportKeyingMaterial to
match the one used in crypto/tls.