### PR TITLE
Use atomic for local/remote epoch

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -140,13 +140,14 @@ func TestExportKeyingMaterial(t *testing.T) {
 		remoteRandom: handshakeRandom{time.Unix(1000, 0), rand},
 		cipherSuite:  &cipherSuiteTLSEcdheEcdsaWithAes128GcmSha256{},
 	}
+	c.setLocalEpoch(0)
 
 	_, err := c.ExportKeyingMaterial(exportLabel, nil, 0)
 	if err != errHandshakeInProgress {
 		t.Errorf("ExportKeyingMaterial when epoch == 0: expected '%s' actual '%s'", errHandshakeInProgress, err)
 	}
 
-	c.localEpoch = 1
+	c.setLocalEpoch(1)
 	_, err = c.ExportKeyingMaterial(exportLabel, []byte{0x00}, 0)
 	if err != errContextUnsupported {
 		t.Errorf("ExportKeyingMaterial with context: expected '%s' actual '%s'", errContextUnsupported, err)

--- a/server_handlers.go
+++ b/server_handlers.go
@@ -107,7 +107,7 @@ func serverHandshakeHandler(c *Conn) error {
 				} else if !bytes.Equal(expectedVerifyData, h.verifyData) {
 					return errVerifyDataMismatch
 				}
-				c.localEpoch = 1
+				c.setLocalEpoch(1)
 				c.localSequenceNumber = 5
 				if err := c.currFlight.set(flight6); err != nil {
 					return err


### PR DESCRIPTION
Race was reported around set/get of epoch, instead of juggling mutex
just use an atomic

Resolves #30