### PR TITLE
Implement signature_algorithms extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Check out the **[contributing wiki](https://github.com/pions/webrtc/wiki/Contrib
 
 * [Sean DuBois](https://github.com/Sean-Der) - *Original Author*
 * [Michiel De Backker](https://github.com/backkem) - *Public API*
+* [Chris Hiszpanski](https://github.com/thinkski) - *Support Signature Algorithms Extension*
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/client_handlers.go
+++ b/client_handlers.go
@@ -158,6 +158,13 @@ func clientFlightHandler(c *Conn) (bool, error) {
 						&extensionSupportedPointFormats{
 							pointFormats: []ellipticCurvePointFormat{ellipticCurvePointFormatUncompressed},
 						},
+						&extensionSupportedSignatureAlgorithms{
+							signatureHashAlgorithms: []signatureHashAlgorithm{
+								{HashAlgorithmSHA256, signatureAlgorithmECDSA},
+								{HashAlgorithmSHA384, signatureAlgorithmECDSA},
+								{HashAlgorithmSHA512, signatureAlgorithmECDSA},
+							},
+						},
 					},
 				}},
 		}, false)

--- a/extension.go
+++ b/extension.go
@@ -8,9 +8,10 @@ import (
 type extensionValue uint16
 
 const (
-	extensionSupportedEllipticCurvesValue extensionValue = 10
-	extensionSupportedPointFormatsValue   extensionValue = 11
-	extensionUseSRTPValue                 extensionValue = 14
+	extensionSupportedEllipticCurvesValue      extensionValue = 10
+	extensionSupportedPointFormatsValue        extensionValue = 11
+	extensionSupportedSignatureAlgorithmsValue extensionValue = 13
+	extensionUseSRTPValue                      extensionValue = 14
 )
 
 type extension interface {

--- a/extension_supported_signature_algorithms.go
+++ b/extension_supported_signature_algorithms.go
@@ -1,0 +1,60 @@
+package dtls
+
+import (
+	"encoding/binary"
+)
+
+const (
+	extensionSupportedSignatureAlgorithmsHeaderSize = 6
+)
+
+// https://tools.ietf.org/html/rfc5246#section-7.4.1.4.1
+type extensionSupportedSignatureAlgorithms struct {
+	signatureHashAlgorithms []signatureHashAlgorithm
+}
+
+func (e extensionSupportedSignatureAlgorithms) extensionValue() extensionValue {
+	return extensionSupportedSignatureAlgorithmsValue
+}
+
+func (e *extensionSupportedSignatureAlgorithms) Marshal() ([]byte, error) {
+	out := make([]byte, extensionSupportedSignatureAlgorithmsHeaderSize)
+
+	binary.BigEndian.PutUint16(out, uint16(e.extensionValue()))
+	binary.BigEndian.PutUint16(out[2:], uint16(2+(len(e.signatureHashAlgorithms)*2)))
+	binary.BigEndian.PutUint16(out[4:], uint16(len(e.signatureHashAlgorithms)*2))
+	for _, v := range e.signatureHashAlgorithms {
+		out = append(out, []byte{0x00, 0x00}...)
+		out[len(out)-2] = byte(v.hash)
+		out[len(out)-1] = byte(v.signature)
+	}
+
+	return out, nil
+}
+
+func (e *extensionSupportedSignatureAlgorithms) Unmarshal(data []byte) error {
+	if len(data) <= extensionSupportedSignatureAlgorithmsHeaderSize {
+		return errBufferTooSmall
+	} else if extensionValue(binary.BigEndian.Uint16(data)) != e.extensionValue() {
+		return errInvalidExtensionType
+	}
+
+	algorithmCount := int(binary.BigEndian.Uint16(data[4:]) / 2)
+	if extensionSupportedSignatureAlgorithmsHeaderSize+(algorithmCount*2) > len(data) {
+		return errLengthMismatch
+	}
+	for i := 0; i < algorithmCount; i++ {
+		supportedHashAlgorithm := HashAlgorithm(data[extensionSupportedSignatureAlgorithmsHeaderSize+(i*2)])
+		supportedSignatureAlgorithm := signatureAlgorithm(data[extensionSupportedSignatureAlgorithmsHeaderSize+(i*2)+1])
+		if _, ok := hashAlgorithms[supportedHashAlgorithm]; ok {
+			if _, ok := signatureAlgorithms[supportedSignatureAlgorithm]; ok {
+				e.signatureHashAlgorithms = append(e.signatureHashAlgorithms, signatureHashAlgorithm{
+					supportedHashAlgorithm,
+					supportedSignatureAlgorithm,
+				})
+			}
+		}
+	}
+
+	return nil
+}

--- a/extension_supported_signature_algorithms_test.go
+++ b/extension_supported_signature_algorithms_test.go
@@ -1,0 +1,32 @@
+package dtls
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestExtensionSupportedSignatureAlgorithms(t *testing.T) {
+
+	rawExtensionSupportedSignatureAlgorithms := []byte{
+		0x00, 0x0d,
+		0x00, 0x08,
+		0x00, 0x06,
+		0x04, 0x03,
+		0x05, 0x03,
+		0x06, 0x03,
+	}
+	parsedExtensionSupportedSignatureAlgorithms := &extensionSupportedSignatureAlgorithms{
+		signatureHashAlgorithms: []signatureHashAlgorithm{
+			{HashAlgorithmSHA256, signatureAlgorithmECDSA},
+			{HashAlgorithmSHA384, signatureAlgorithmECDSA},
+			{HashAlgorithmSHA512, signatureAlgorithmECDSA},
+		},
+	}
+
+	raw, err := parsedExtensionSupportedSignatureAlgorithms.Marshal()
+	if err != nil {
+		t.Error(err)
+	} else if !reflect.DeepEqual(raw, rawExtensionSupportedSignatureAlgorithms) {
+		t.Errorf("extensionSupportedSignatureAlgorithms marshal: got %#v, want %#v", raw, rawExtensionSupportedSignatureAlgorithms)
+	}
+}


### PR DESCRIPTION
Client uses extension to indicate to server which signature/hash
algorithm pairs may be used. Without this extensions, some servers
choose unsupported pairs, resulting in failure to connect.