### PR TITLE
Fix multiple issues found by issue-32

### DIFF
--- a/client_handlers.go
+++ b/client_handlers.go
@@ -99,7 +99,7 @@ func clientHandshakeHandler(c *Conn) error {
 					return err
 				}
 
-				expectedHash := valueKeySignature(clientRandom, serverRandom, h.publicKey, c.namedCurve, h.hashAlgorithm)
+				expectedHash := valueKeySignature(clientRandom, serverRandom, h.publicKey, h.namedCurve, h.hashAlgorithm)
 				if err := verifyKeySignature(expectedHash, h.signature, c.remoteCertificate); err != nil {
 					return err
 				}

--- a/config.go
+++ b/config.go
@@ -8,6 +8,18 @@ import (
 // Config is used to configure a DTLS client or server.
 // After a Config is passed to a DTLS function it must not be modified.
 type Config struct {
+	// Certificates contains certificate chain to present to
+	// the other side of the connection. Server MUST set this,
+	// client SHOULD sets this so CertificateRequests
+	// can be handled
 	Certificate *x509.Certificate
-	PrivateKey  crypto.PrivateKey
+
+	// PrivateKey contains matching private key for the certificate
+	// only ECDSA is supported
+	PrivateKey crypto.PrivateKey
+
+	// SRTPProtectionProfiles are the supported protection profiles
+	// Clients will send this via use_srtp and assert that the server properly responds
+	// Servers will assert that clients send one of these profiles and will respond as needed
+	SRTPProtectionProfiles []SRTPProtectionProfile
 }

--- a/extension_use_srtp.go
+++ b/extension_use_srtp.go
@@ -8,7 +8,7 @@ const (
 
 // https://tools.ietf.org/html/rfc8422
 type extensionUseSRTP struct {
-	protectionProfiles []srtpProtectionProfile
+	protectionProfiles []SRTPProtectionProfile
 }
 
 func (e extensionUseSRTP) extensionValue() extensionValue {
@@ -44,7 +44,7 @@ func (e *extensionUseSRTP) Unmarshal(data []byte) error {
 	}
 
 	for i := 0; i < profileCount; i++ {
-		supportedProfile := srtpProtectionProfile(binary.BigEndian.Uint16(data[(extensionUseSRTPHeaderSize + (i * 2)):]))
+		supportedProfile := SRTPProtectionProfile(binary.BigEndian.Uint16(data[(extensionUseSRTPHeaderSize + (i * 2)):]))
 		if _, ok := srtpProtectionProfiles[supportedProfile]; ok {
 			e.protectionProfiles = append(e.protectionProfiles, supportedProfile)
 		}

--- a/extension_use_srtp_test.go
+++ b/extension_use_srtp_test.go
@@ -8,7 +8,7 @@ import (
 func TestExtensionUseSRTP(t *testing.T) {
 	rawUseSRTP := []byte{0x00, 0x0e, 0x00, 0x05, 0x00, 0x02, 0x00, 0x01, 0x00}
 	parsedUseSRTP := &extensionUseSRTP{
-		protectionProfiles: []srtpProtectionProfile{SRTP_AES128_CM_HMAC_SHA1_80},
+		protectionProfiles: []SRTPProtectionProfile{SRTP_AES128_CM_HMAC_SHA1_80},
 	}
 
 	raw, err := parsedUseSRTP.Marshal()

--- a/srtp_protection_profile.go
+++ b/srtp_protection_profile.go
@@ -1,11 +1,13 @@
 package dtls
 
-type srtpProtectionProfile uint16
+// SRTPProtectionProfile defines the parameters and options that are in effect for the SRTP processing
+// https://tools.ietf.org/html/rfc5764#section-4.1.2
+type SRTPProtectionProfile uint16
 
 const (
-	SRTP_AES128_CM_HMAC_SHA1_80 srtpProtectionProfile = 0x0001 // nolint
+	SRTP_AES128_CM_HMAC_SHA1_80 SRTPProtectionProfile = 0x0001 // nolint
 )
 
-var srtpProtectionProfiles = map[srtpProtectionProfile]bool{
+var srtpProtectionProfiles = map[SRTPProtectionProfile]bool{
 	SRTP_AES128_CM_HMAC_SHA1_80: true,
 }

--- a/util.go
+++ b/util.go
@@ -130,3 +130,14 @@ func examinePadding(payload []byte) (toRemove int, good byte) {
 
 	return toRemove, good
 }
+
+func findMatchingSRTPProfile(a, b []SRTPProtectionProfile) (SRTPProtectionProfile, bool) {
+	for _, aProfile := range a {
+		for _, bProfile := range b {
+			if aProfile == bProfile {
+				return aProfile, true
+			}
+		}
+	}
+	return 0, false
+}


### PR DESCRIPTION
This makes the `use_srtp` extensions conditional. We will need to update pion-WebRTC to pass the protection profiles (very simple change).

This also fixes how we chose which NamedCurve to use, the Client passes what it supports and the server makes the final choice. We accidentally used the clients choice.
