### PR TITLE
Implement resuming a connection from a previously serialized state

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Check out the **[contributing wiki](https://github.com/pions/webrtc/wiki/Contrib
 * [Sean DuBois](https://github.com/Sean-Der) - *Original Author*
 * [Michiel De Backker](https://github.com/backkem) - *Public API*
 * [Chris Hiszpanski](https://github.com/thinkski) - *Support Signature Algorithms Extension*
+* [Iñigo Garcia Olaizola](https://github.com/igolaizola) - *Support serialization and resumption"
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/conn.go
+++ b/conn.go
@@ -36,31 +36,25 @@ type Conn struct {
 	decrypted      chan []byte     // Decrypted Application Data, pull by calling `Read`
 	workerTicker   *time.Ticker
 
-	isClient                   bool
+	state State // Internal state
+
 	remoteRequestedCertificate bool // Did we get a CertificateRequest
-	localEpoch, remoteEpoch    atomic.Value
-	localSequenceNumber        uint64 // uint48
 
 	localSRTPProtectionProfiles []SRTPProtectionProfile // Available SRTPProtectionProfiles, if empty no SRTP support
-	srtpProtectionProfile       SRTPProtectionProfile   // Negotiated SRTPProtectionProfile
 
 	clientAuth ClientAuthType // If we are a client should we request a client certificate
 
-	currFlight                          *flight
-	cipherSuite                         cipherSuite // nil if a cipherSuite hasn't been chosen
-	namedCurve                          namedCurve
-	localRandom, remoteRandom           handshakeRandom
-	localCertificate, remoteCertificate *x509.Certificate
-	localPrivateKey                     crypto.PrivateKey
-	localKeypair, remoteKeypair         *namedCurveKeypair
-	cookie                              []byte
+	currFlight                  *flight
+	namedCurve                  namedCurve
+	localCertificate            *x509.Certificate
+	localPrivateKey             crypto.PrivateKey
+	localKeypair, remoteKeypair *namedCurveKeypair
+	cookie                      []byte
 
 	localCertificateVerify    []byte // cache CertificateVerify
 	localVerifyData           []byte // cached VerifyData
 	localKeySignature         []byte // cached keySignature
 	remoteCertificateVerified bool
-
-	masterSecret []byte
 
 	handshakeMessageHandler handshakeMessageHandler
 	flightHandler           flightHandler
@@ -88,7 +82,6 @@ func createConn(nextConn net.Conn, flightHandler flightHandler, handshakeMessage
 	}
 
 	c := &Conn{
-		isClient:                    isClient,
 		nextConn:                    nextConn,
 		currFlight:                  newFlight(isClient),
 		fragmentBuffer:              newFragmentBuffer(),
@@ -105,12 +98,13 @@ func createConn(nextConn net.Conn, flightHandler flightHandler, handshakeMessage
 		workerTicker:       time.NewTicker(workerInterval),
 		handshakeCompleted: make(chan bool),
 	}
+	c.state.isClient = isClient
 
 	var zeroEpoch uint16
-	c.localEpoch.Store(zeroEpoch)
-	c.remoteEpoch.Store(zeroEpoch)
+	c.state.localEpoch.Store(zeroEpoch)
+	c.state.remoteEpoch.Store(zeroEpoch)
 
-	err := c.localRandom.populate()
+	err := c.state.localRandom.populate()
 	if err != nil {
 		return nil, err
 	}
@@ -201,14 +195,14 @@ func (c *Conn) Write(p []byte) (int, error) {
 	c.internalSend(&recordLayer{
 		recordLayerHeader: recordLayerHeader{
 			epoch:           c.getLocalEpoch(),
-			sequenceNumber:  c.localSequenceNumber,
+			sequenceNumber:  c.state.localSequenceNumber,
 			protocolVersion: protocolVersion1_2,
 		},
 		content: &applicationData{
 			data: p,
 		},
 	}, true)
-	c.localSequenceNumber++
+	c.state.localSequenceNumber++
 
 	return len(p), nil
 }
@@ -227,7 +221,7 @@ func (c *Conn) Close() error {
 func (c *Conn) RemoteCertificate() *x509.Certificate {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
-	return c.remoteCertificate
+	return c.state.remoteCertificate
 }
 
 // SelectedSRTPProtectionProfile returns the selected SRTPProtectionProfile
@@ -235,11 +229,11 @@ func (c *Conn) SelectedSRTPProtectionProfile() (SRTPProtectionProfile, bool) {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
 
-	if c.srtpProtectionProfile == 0 {
+	if c.state.srtpProtectionProfile == 0 {
 		return 0, false
 	}
 
-	return c.srtpProtectionProfile, true
+	return c.state.srtpProtectionProfile, true
 }
 
 // ExportKeyingMaterial from https://tools.ietf.org/html/rfc5705
@@ -257,22 +251,22 @@ func (c *Conn) ExportKeyingMaterial(label string, context []byte, length int) ([
 		return nil, errReservedExportKeyingMaterial
 	}
 
-	localRandom, err := c.localRandom.Marshal()
+	localRandom, err := c.state.localRandom.Marshal()
 	if err != nil {
 		return nil, err
 	}
-	remoteRandom, err := c.remoteRandom.Marshal()
+	remoteRandom, err := c.state.remoteRandom.Marshal()
 	if err != nil {
 		return nil, err
 	}
 
 	seed := []byte(label)
-	if c.isClient {
+	if c.state.isClient {
 		seed = append(append(seed, localRandom...), remoteRandom...)
 	} else {
 		seed = append(append(seed, remoteRandom...), localRandom...)
 	}
-	return prfPHash(c.masterSecret, seed, length, c.cipherSuite.hashFunc())
+	return prfPHash(c.state.masterSecret, seed, length, c.state.cipherSuite.hashFunc())
 }
 
 func (c *Conn) internalSend(pkt *recordLayer, shouldEncrypt bool) {
@@ -283,11 +277,11 @@ func (c *Conn) internalSend(pkt *recordLayer, shouldEncrypt bool) {
 	}
 
 	if h, ok := pkt.content.(*handshake); ok {
-		c.handshakeCache.push(raw[recordLayerHeaderSize:], h.handshakeHeader.messageSequence, h.handshakeHeader.handshakeType, c.isClient)
+		c.handshakeCache.push(raw[recordLayerHeaderSize:], h.handshakeHeader.messageSequence, h.handshakeHeader.handshakeType, c.state.isClient)
 	}
 
 	if shouldEncrypt {
-		raw, err = c.cipherSuite.encrypt(pkt, raw)
+		raw, err = c.state.cipherSuite.encrypt(pkt, raw)
 		if err != nil {
 			c.stopWithError(err)
 			return
@@ -328,13 +322,13 @@ func (c *Conn) handleIncomingPacket(buf []byte) error {
 	}
 
 	if h.epoch != 0 {
-		if c.cipherSuite == nil {
+		if c.state.cipherSuite == nil {
 			fmt.Println("handleIncoming: Handshake not finished, dropping packet")
 			return nil
 		}
 
 		var err error
-		buf, err = c.cipherSuite.decrypt(buf)
+		buf, err = c.state.cipherSuite.decrypt(buf)
 		if err != nil {
 			fmt.Println(err)
 			return nil
@@ -352,7 +346,7 @@ func (c *Conn) handleIncomingPacket(buf []byte) error {
 				return err
 			}
 
-			if c.handshakeCache.push(out, rawHandshake.handshakeHeader.messageSequence, rawHandshake.handshakeHeader.handshakeType, !c.isClient) {
+			if c.handshakeCache.push(out, rawHandshake.handshakeHeader.messageSequence, rawHandshake.handshakeHeader.handshakeType, !c.state.isClient) {
 				newHandshakeMessage = true
 			}
 		}
@@ -393,7 +387,7 @@ func (c *Conn) notify(level alertLevel, desc alertDescription) {
 	c.internalSend(&recordLayer{
 		recordLayerHeader: recordLayerHeader{
 			epoch:           c.getLocalEpoch(),
-			sequenceNumber:  c.localSequenceNumber,
+			sequenceNumber:  c.state.localSequenceNumber,
 			protocolVersion: protocolVersion1_2,
 		},
 		content: &alert{
@@ -402,7 +396,7 @@ func (c *Conn) notify(level alertLevel, desc alertDescription) {
 		},
 	}, true)
 
-	c.localSequenceNumber++
+	c.state.localSequenceNumber++
 }
 
 func (c *Conn) signalHandshakeComplete() {
@@ -463,19 +457,19 @@ func (c *Conn) getConnErr() error {
 }
 
 func (c *Conn) setLocalEpoch(epoch uint16) {
-	c.localEpoch.Store(epoch)
+	c.state.localEpoch.Store(epoch)
 }
 
 func (c *Conn) getLocalEpoch() uint16 {
-	return c.localEpoch.Load().(uint16)
+	return c.state.localEpoch.Load().(uint16)
 }
 
 func (c *Conn) setRemoteEpoch(epoch uint16) {
-	c.remoteEpoch.Store(epoch)
+	c.state.remoteEpoch.Store(epoch)
 }
 
 func (c *Conn) getRemoteEpoch() uint16 {
-	return c.remoteEpoch.Load().(uint16)
+	return c.state.remoteEpoch.Load().(uint16)
 }
 
 // LocalAddr is a stub

--- a/conn_test.go
+++ b/conn_test.go
@@ -129,9 +129,11 @@ func TestExportKeyingMaterial(t *testing.T) {
 	expectedClientKey := []byte{0x87, 0xf0, 0x40, 0x02, 0xf6, 0x1c, 0xf1, 0xfe, 0x8c, 0x77}
 
 	c := &Conn{
-		localRandom:  handshakeRandom{time.Unix(500, 0), rand},
-		remoteRandom: handshakeRandom{time.Unix(1000, 0), rand},
-		cipherSuite:  &cipherSuiteTLSEcdheEcdsaWithAes128GcmSha256{},
+		state: State{
+			localRandom:  handshakeRandom{time.Unix(500, 0), rand},
+			remoteRandom: handshakeRandom{time.Unix(1000, 0), rand},
+			cipherSuite:  &cipherSuiteTLSEcdheEcdsaWithAes128GcmSha256{},
+		},
 	}
 	c.setLocalEpoch(0)
 
@@ -160,7 +162,7 @@ func TestExportKeyingMaterial(t *testing.T) {
 		t.Errorf("ExportKeyingMaterial client export: expected (% 02x) actual (% 02x)", expectedServerKey, keyingMaterial)
 	}
 
-	c.isClient = true
+	c.state.isClient = true
 	keyingMaterial, err = c.ExportKeyingMaterial(exportLabel, nil, 10)
 	if err != nil {
 		t.Errorf("ExportKeyingMaterial as server: unexpected error '%s'", err)

--- a/resume.go
+++ b/resume.go
@@ -1,0 +1,36 @@
+package dtls
+
+import (
+	"net"
+)
+
+// Export extracts dtls state and inner connection from an already handshaked dtls conn
+func (c *Conn) Export() (*State, net.Conn, error) {
+	state, err := c.state.clone()
+	if err != nil {
+		return nil, nil, err
+	}
+	return state, c.nextConn, nil
+}
+
+// Resume imports an already stablished dtls connection using a specific dtls state
+func Resume(state *State, conn net.Conn, config *Config) (*Conn, error) {
+	// Custom flight handler that sets imported data and signals as handshaked
+	flightHandler := func(c *Conn) (bool, error) {
+		c.state = *state
+		c.signalHandshakeComplete()
+		return true, nil
+	}
+
+	// Empty handshake handler, since handshake was already done
+	handshakeHandler := func(c *Conn) error {
+		return nil
+	}
+
+	c, err := createConn(conn, flightHandler, handshakeHandler, config, state.isClient)
+	if err != nil {
+		return nil, err
+	}
+
+	return c, c.getConnErr()
+}

--- a/resume_test.go
+++ b/resume_test.go
@@ -1,0 +1,189 @@
+package dtls
+
+import (
+	"bytes"
+	"fmt"
+	"net"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestResumeClient(t *testing.T) {
+	DoTestResume(t, Client, Server)
+}
+
+func TestResumeServer(t *testing.T) {
+	DoTestResume(t, Server, Client)
+}
+
+func fatal(t *testing.T, errChan chan error, err error) {
+	close(errChan)
+	t.Fatal(err)
+}
+
+func DoTestResume(t *testing.T, newLocal, newRemote func(net.Conn, *Config) (*Conn, error)) {
+	certificate, privateKey, err := GenerateSelfSigned()
+	if err != nil {
+		t.Fatal(err)
+	}
+	config := &Config{Certificate: certificate, PrivateKey: privateKey}
+
+	// Generate connections
+	localConn1, rc1 := net.Pipe()
+	localConn2, rc2 := net.Pipe()
+	remoteConn := &backupConn{curr: rc1, next: rc2}
+
+	// Launch remote in another goroutine
+	errChan := make(chan error, 1)
+	defer func() {
+		err = <-errChan
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+	go func() {
+		var remote *Conn
+		var errR error
+		remote, errR = newRemote(remoteConn, config)
+		if errR != nil {
+			errChan <- errR
+		}
+
+		// Loop of read write
+		for i := 0; i < 2; i++ {
+			recv := make([]byte, 1024)
+			var n int
+			n, errR = remote.Read(recv)
+			if errR != nil {
+				errChan <- errR
+			}
+
+			if _, errR = remote.Write(recv[:n]); errR != nil {
+				errChan <- errR
+			}
+		}
+		errChan <- nil
+	}()
+
+	var local *Conn
+	local, err = newLocal(localConn1, config)
+	if err != nil {
+		fatal(t, errChan, err)
+	}
+
+	// Test write and read
+	message := []byte("Hello")
+	if _, err = local.Write(message); err != nil {
+		fatal(t, errChan, err)
+	}
+
+	recv := make([]byte, 1024)
+	var n int
+	n, err = local.Read(recv)
+	if err != nil {
+		fatal(t, errChan, err)
+	}
+
+	if !bytes.Equal(message, recv[:n]) {
+		fatal(t, errChan, fmt.Errorf("messages missmatch: %s != %s", message, recv[:n]))
+	}
+
+	// Export dtls connection
+	var state *State
+	var innerConn net.Conn
+	state, innerConn, err = local.Export()
+	if err != nil {
+		fatal(t, errChan, err)
+	}
+	if err = innerConn.Close(); err != nil {
+		fatal(t, errChan, err)
+	}
+
+	// Serialize and deserialize state
+	var b []byte
+	b, err = state.MarshalBinary()
+	if err != nil {
+		fatal(t, errChan, err)
+	}
+	deserialized := &State{}
+	if err = deserialized.UnmarshalBinary(b); err != nil {
+		fatal(t, errChan, err)
+	}
+
+	// Resume dtls connection
+	var resumed net.Conn
+	resumed, err = Resume(state, localConn2, config)
+	if err != nil {
+		fatal(t, errChan, err)
+	}
+
+	// Test write and read on resumed connection
+	if _, err = resumed.Write(message); err != nil {
+		fatal(t, errChan, err)
+	}
+
+	recv = make([]byte, 1024)
+	n, err = resumed.Read(recv)
+	if err != nil {
+		fatal(t, errChan, err)
+	}
+
+	if !bytes.Equal(message, recv[:n]) {
+		fatal(t, errChan, fmt.Errorf("messages missmatch: %s != %s", message, recv[:n]))
+	}
+}
+
+type backupConn struct {
+	curr net.Conn
+	next net.Conn
+	mux  sync.Mutex
+}
+
+func (b *backupConn) Read(data []byte) (n int, err error) {
+	n, err = b.curr.Read(data)
+	if err != nil && b.next != nil {
+		b.mux.Lock()
+		b.curr = b.next
+		b.next = nil
+		b.mux.Unlock()
+		return b.Read(data)
+	}
+	return n, err
+}
+
+func (b *backupConn) Write(data []byte) (n int, err error) {
+	n, err = b.curr.Write(data)
+	if err != nil && b.next != nil {
+		b.mux.Lock()
+		b.curr = b.next
+		b.next = nil
+		b.mux.Unlock()
+		return b.Write(data)
+	}
+	return n, err
+}
+
+func (b *backupConn) Close() error {
+	return nil
+}
+
+func (b *backupConn) LocalAddr() net.Addr {
+	return nil
+}
+
+func (b *backupConn) RemoteAddr() net.Addr {
+	return nil
+}
+
+func (b *backupConn) SetDeadline(t time.Time) error {
+	return nil
+}
+
+func (b *backupConn) SetReadDeadline(t time.Time) error {
+	return nil
+}
+
+func (b *backupConn) SetWriteDeadline(t time.Time) error {
+	return nil
+}

--- a/state.go
+++ b/state.go
@@ -1,0 +1,159 @@
+package dtls
+
+import (
+	"bytes"
+	"crypto/x509"
+	"encoding/gob"
+	"sync/atomic"
+)
+
+// State holds the dtls connection state and implements both encoding.BinaryMarshaler and encoding.BinaryUnmarshaler
+type State struct {
+	localEpoch, remoteEpoch   atomic.Value
+	localSequenceNumber       uint64 // uint48
+	localRandom, remoteRandom handshakeRandom
+	masterSecret              []byte
+	cipherSuite               cipherSuite // nil if a cipherSuite hasn't been chosen
+
+	srtpProtectionProfile SRTPProtectionProfile // Negotiated SRTPProtectionProfile
+	remoteCertificate     *x509.Certificate
+
+	isClient bool
+}
+
+type serializedState struct {
+	LocalEpoch            uint16
+	RemoteEpoch           uint16
+	LocalRandom           []byte
+	RemoteRandom          []byte
+	CipherSuiteID         uint16
+	MasterSecret          []byte
+	SequenceNumber        uint64
+	SRTPProtectionProfile uint16
+	RemoteCertificate     []byte
+	IsClient              bool
+}
+
+func (s *State) clone() (*State, error) {
+	serialized, err := s.serialize()
+	if err != nil {
+		return nil, err
+	}
+	state := &State{}
+	if err := state.deserialize(*serialized); err != nil {
+		return nil, err
+	}
+	return state, nil
+}
+
+func (s *State) serialize() (*serializedState, error) {
+	// Marshal random values
+	localRnd, err := s.localRandom.Marshal()
+	if err != nil {
+		return nil, err
+	}
+	remoteRnd, err := s.remoteRandom.Marshal()
+	if err != nil {
+		return nil, err
+	}
+
+	// Marshal remote certificate
+	var cert []byte
+	if s.remoteCertificate != nil {
+		h := &handshakeMessageCertificate{s.remoteCertificate}
+		cert, err = h.Marshal()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	serialized := serializedState{
+		LocalEpoch:            s.localEpoch.Load().(uint16),
+		RemoteEpoch:           s.remoteEpoch.Load().(uint16),
+		CipherSuiteID:         uint16(s.cipherSuite.ID()),
+		MasterSecret:          s.masterSecret,
+		SequenceNumber:        s.localSequenceNumber,
+		LocalRandom:           localRnd,
+		RemoteRandom:          remoteRnd,
+		SRTPProtectionProfile: uint16(s.srtpProtectionProfile),
+		RemoteCertificate:     cert,
+		IsClient:              s.isClient,
+	}
+
+	return &serialized, nil
+}
+
+func (s *State) deserialize(serialized serializedState) error {
+	// Set epoch values
+	s.localEpoch.Store(serialized.LocalEpoch)
+	s.remoteEpoch.Store(serialized.RemoteEpoch)
+
+	// Set random values
+	localRandom := &handshakeRandom{}
+	if err := localRandom.Unmarshal(serialized.LocalRandom); err != nil {
+		return err
+	}
+	s.localRandom = *localRandom
+	remoteRandom := &handshakeRandom{}
+	if err := remoteRandom.Unmarshal(serialized.RemoteRandom); err != nil {
+		return err
+	}
+	s.remoteRandom = *remoteRandom
+
+	s.isClient = serialized.IsClient
+
+	// Set cipher suite
+	s.cipherSuite = cipherSuiteForID(cipherSuiteID(serialized.CipherSuiteID))
+	var err error
+	if serialized.IsClient {
+		err = s.cipherSuite.init(serialized.MasterSecret, serialized.LocalRandom, serialized.RemoteRandom, true)
+	} else {
+		err = s.cipherSuite.init(serialized.MasterSecret, serialized.RemoteRandom, serialized.LocalRandom, false)
+	}
+	if err != nil {
+		return err
+	}
+
+	s.localSequenceNumber = serialized.SequenceNumber
+	s.srtpProtectionProfile = SRTPProtectionProfile(serialized.SRTPProtectionProfile)
+
+	// Set remote certificate
+	if serialized.RemoteCertificate != nil {
+		h := &handshakeMessageCertificate{}
+		if err := h.Unmarshal(serialized.RemoteCertificate); err != nil {
+			return err
+		}
+		s.remoteCertificate = h.certificate
+	}
+
+	return nil
+}
+
+// MarshalBinary is a binary.BinaryMarshaler.MarshalBinary implementation
+func (s *State) MarshalBinary() ([]byte, error) {
+	serialized, err := s.serialize()
+	if err != nil {
+		return nil, err
+	}
+
+	var buf bytes.Buffer
+	enc := gob.NewEncoder(&buf)
+	if err := enc.Encode(*serialized); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// UnmarshalBinary is a binary.BinaryUnmarshaler.UnmarshalBinary implementation
+func (s *State) UnmarshalBinary(data []byte) error {
+	enc := gob.NewDecoder(bytes.NewBuffer(data))
+	var serialized serializedState
+	if err := enc.Decode(&serialized); err != nil {
+		return err
+	}
+
+	if err := s.deserialize(serialized); err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
New feature to export dtls state of an already running dtls connection in order to be able to resume it later. 

Use case:

Serialize and persist to an external data source the dtls state in order to resume it from a different running instance of the application, avoiding performing a new handshake.